### PR TITLE
Use the ColorPropType to validate colors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from "prop-types"
 import {
   ViewPropTypes,
+  ColorPropType,
   StyleSheet,
   Animated,
   Easing,
@@ -16,10 +17,10 @@ export default class extends Component {
     value: PropTypes.bool,
     defaultValue: PropTypes.bool,
     disabled: PropTypes.bool,
-    circleColorActive: PropTypes.string,
-    circleColorInactive: PropTypes.string,
-    backgroundActive: PropTypes.string,
-    backgroundInactive: PropTypes.string,
+    circleColorActive: ColorPropType,
+    circleColorInactive: ColorPropType,
+    backgroundActive: ColorPropType,
+    backgroundInactive: ColorPropType,
     onAsyncPress: PropTypes.func,
     onSyncPress: PropTypes.func,
     style: ViewPropTypes.style


### PR DESCRIPTION
Better validation; avoid warning on colors with opacity, etc.