### PR TITLE
adds circleStyle property

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ defaultValue | default state of switch | false | bool
 disabled | whether switch is clickable | false | bool
 circleColorActive | color for circle handler of switch when it is on | white | string
 circleColorInactive | color for circle handler of switch when it is off | white | string
+circleStyle | styles that will be applied for the circle | undefined | style
 backgroundActive | color of switch when it is on | green | string
 backgroundInactive | color of switch when it is off | '#ddd' | string
 onSyncPress | callback when switch is clicked | () => null | func

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,8 @@ export default class extends Component {
     backgroundInactive: ColorPropType,
     onAsyncPress: PropTypes.func,
     onSyncPress: PropTypes.func,
-    style: ViewPropTypes.style
+    style: ViewPropTypes.style,
+    circleStyle: ViewPropTypes.style
   }
 
   static defaultProps = {
@@ -159,6 +160,7 @@ export default class extends Component {
     const {
       backgroundActive, backgroundInactive,
       width, height, circleColorActive, circleColorInactive, style,
+      circleStyle,
       ...rest
     } = this.props
 
@@ -181,13 +183,13 @@ export default class extends Component {
           alignItems,
           borderRadius: height / 2,
           backgroundColor: interpolatedBackgroundColor }]}>
-        <Animated.View style={{
+        <Animated.View style={[{
           backgroundColor: interpolatedCircleColor,
           width: handlerAnimation,
           height: this.handlerSize,
           borderRadius: height / 2,
           transform: [{ translateX: switchAnimation }]
-        }} />
+        }, circleStyle]} />
       </Animated.View>
     )
   }


### PR DESCRIPTION
this is useful, for example, when the switch background has the same color
as the circle (e.g. white) and one wants to add a border:

circleStyle={{borderWidth:1, borderColor: 'grey'}}