### PR TITLE
fix a switch flipping twice with one toggle

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,20 +57,10 @@ export default class extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps === this.props) {
-      return
-    }
-
-    // componentWillReceiveProps will still be triggered if
-    // render function of father component is triggered.
-    // Thus, toggleSwitch will be executed without two-way bind.
     if (typeof nextProps.value !== 'undefined' && nextProps.value !== this.props.value) {
-      /** you can add animation when changing value programmatically like following:
-      /* this.animateHandler(this.handlerSize * SCALE, () => {
-      /*   this.toggleSwitch(true)
-      /*  })
-       **/
-      this.toggleSwitch(true)
+      this.animateSwitch(nextProps.value, () => {
+        this.setState({ value: nextProps.value })
+      })
     }
   }
 


### PR DESCRIPTION
The problem is discussed here https://github.com/poberwong/react-native-switch-pro/issues/25. It gives both the issue and the fix. 

The reason for this flipping twice bug is, the state is changed and then flipped back due to the implementation of `componentWillReceiveProps`.

With the implementation I gave, I am setting a state directly with the expected value, NOT assuming it has never been updated and just flipping the state is safe.
