### PR TITLE
Change style prop order to overriding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -210,11 +210,11 @@ export default class extends Component {
       <Animated.View
         {...rest}
         {...this._panResponder.panHandlers}
-        style={[styles.container, style, {
+        style={[styles.container, {
           width, height,
           alignItems,
           borderRadius: height / 2,
-          backgroundColor: interpolatedBackgroundColor }]}>
+          backgroundColor: interpolatedBackgroundColor }, style]}>
         <Animated.View style={[{
           backgroundColor: interpolatedCircleColor,
           width: handlerAnimation,


### PR DESCRIPTION
Placing the `prop.style` as the last style to be applied enables 2 benefits:

1. The user has full control over the styling of the switch
2. Can adopt `material` standard design (with the handler bigger than the bar)

How to get the `material` style?

1. Give the Switch a height as the handle will have
2. Limit the handler height with the `prop.style`

```js
<Switch
  height={24}
  circleStyle={{ height: 24, width: 24 }}
  style={{ height: 16 }}
/>
```

Hence producing something like:

![kapture 2018-08-27 at 13 13 15](https://user-images.githubusercontent.com/3116899/44656885-00329300-a9fb-11e8-87b6-6755f4b735da.gif)
