### PR TITLE
Correct positioning when using border styles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -200,9 +200,24 @@ export default class extends Component {
       extrapolate: 'clamp'
     })
 
+    const circlePosition = (value) => {
+      const modifier = value ? 1 : -1
+      let position = modifier * -1
+
+      if (circleStyle && circleStyle.borderWidth) {
+        position += modifier
+      }
+
+      if (style && style.borderWidth) {
+        position += modifier
+      }
+
+      return position
+    }
+
     const interpolatedTranslateX = switchAnimation.interpolate({
       inputRange: value ? [-this.offset, -1]: [1, this.offset],
-      outputRange: value ? [-this.offset, -1]: [1, this.offset],
+      outputRange: value ? [-this.offset, circlePosition(value)]: [circlePosition(value), this.offset],
       extrapolate: 'clamp'
     })
 


### PR DESCRIPTION
This PR addresses the issue reported in https://github.com/poberwong/react-native-switch-pro/issues/22

A preview is available online at: https://snack.expo.io/@mbezhanov/rnsp-borders-demo

The positioning issues are corrected by tweaking the `translateX` property of the circle, when borders are present.