### PR TITLE
added useNativeDriver to animations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,8 @@ export default class extends Component {
       {
         toValue: value ? this.offset : -this.offset,
         duration: 200,
-        easing: Easing.linear
+        easing: Easing.linear,
+        useNativeDriver: false
       }
     ).start(callback)
   }
@@ -174,7 +175,8 @@ export default class extends Component {
       {
         toValue: value,
         duration: 200,
-        easing: Easing.linear
+        easing: Easing.linear,
+        useNativeDriver: false
       }
     ).start(callback)
   }


### PR DESCRIPTION
Hi! React Native 0.62 introduced a new warning regarding the Animated API. You now have to explicitly set useNativeDriver. This has no impact on functionality at the moment, but hides the warning. 