### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ export default class extends Component {
   }
 
   constructor (props, context) {
-    super(props, context)
+    super()
     const { width, height, value } = props
 
     this.offset = width - height + 1
@@ -66,7 +66,7 @@ export default class extends Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     // unify inner state and outer props
     if (this.props.value === this.state.value) {
       return

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ export default class extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     // unify inner state and outer props
-    if (this.props.value == this.state.value) {
+    if (this.props.value === this.state.value) {
       return
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,36 +46,6 @@ export default class extends Component {
     this.offset = width - height + 1
     this.handlerSize = height - 2
 
-    this.state = {
-      value,
-      toggleable: true,
-      alignItems: value ? 'flex-end' : 'flex-start',
-      handlerAnimation: new Animated.Value(this.handlerSize),
-      switchAnimation: new Animated.Value(value ? -1 : 1)
-    }
-  }
-
-  componentWillReceiveProps (nextProps) {
-    // unify inner state and outer props
-    if (nextProps.value === this.state.value) {
-      return
-    }
-
-    if (typeof nextProps.value !== 'undefined' && nextProps.value !== this.props.value) {
-      /**
-       /* you can add animation when changing value programmatically like following:
-       /* this.animateHandler(this.handlerSize * SCALE, () => {
-      /*   setTimeout(() => {
-      /*    this.toggleSwitchToValue(true, nextProps.value)
-      /*    }, 800)
-      /* })
-       */
-      this.toggleSwitchToValue(true, nextProps.value)
-    }
-  }
-
-
-  componentWillMount () {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (evt, gestureState) => true,
       onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
@@ -86,8 +56,35 @@ export default class extends Component {
       onPanResponderMove: this._onPanResponderMove,
       onPanResponderRelease: this._onPanResponderRelease
     })
+
+    this.state = {
+      value,
+      toggleable: true,
+      alignItems: value ? 'flex-end' : 'flex-start',
+      handlerAnimation: new Animated.Value(this.handlerSize),
+      switchAnimation: new Animated.Value(value ? -1 : 1)
+    }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    // unify inner state and outer props
+    if (this.props.value == this.state.value) {
+      return
+    }
+
+    if (typeof this.props.value !== 'undefined' && this.props.value !== prevProps.value) {
+      /**
+       /* you can add animation when changing value programmatically like following:
+       /* this.animateHandler(this.handlerSize * SCALE, () => {
+      /*   setTimeout(() => {
+      /*    this.toggleSwitchToValue(true, nextProps.value)
+      /*    }, 800)
+      /* })
+       */
+      this.toggleSwitchToValue(true, this.props.value)
+    }
+  }
+  
   _onPanResponderGrant = (evt, gestureState) => {
     const { disabled } = this.props
     if (disabled) return


### PR DESCRIPTION
Disclaimer: I have no experience with creating modules and this is my first PR on one.

Not sure if the props/state related code changes are semantically the same as `master`, and not sure if `PanResponder.create(...)` can be safely moved to the constructor, but for me this does the job so far.